### PR TITLE
[DEV-377] added cloudflare credentails dummy

### DIFF
--- a/.github/workflows/terraform_ci.yml
+++ b/.github/workflows/terraform_ci.yml
@@ -9,6 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
+      - run: mkdir ~/.cloudflare && touch ~/.cloudflare/credentials
       - run: docker-compose config -q
   terraform-fmt-and-validate:
     runs-on: ubuntu-latest

--- a/.github/workflows/terraform_ci.yml
+++ b/.github/workflows/terraform_ci.yml
@@ -9,6 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
+      - run: mkdir ~/.github && touch ~/.github/credentials
       - run: mkdir ~/.cloudflare && touch ~/.cloudflare/credentials
       - run: docker-compose config -q
   terraform-fmt-and-validate:


### PR DESCRIPTION
A number of docker-compose files leverage this file for running cloudflare items.  The CI needs a dummy file to not fail.